### PR TITLE
Feature validation single text field

### DIFF
--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		129B09CA12CF36CB8979C44E6CB817EA /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6604A7D69453B4569E4E4827FB9155A9 /* Foundation.framework */; };
 		13D498F23038EE5CBF06204DFDDE3A96 /* Pods-SurveyNative_Example-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = F387F892D5436E82C08E4106EE28C98F /* Pods-SurveyNative_Example-dummy.m */; };
 		15A2B4C51A4C7F6EFB483327A7DE94C7 /* Pods-SurveyNative_Tests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = A9E4ADCCDD0D4E2EEAF2D66E1B7F28A9 /* Pods-SurveyNative_Tests-dummy.m */; };
+		173F3C441ED2290E00FAA3C8 /* ValidationFailedDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 173F3C421ED2290500FAA3C8 /* ValidationFailedDelegate.swift */; };
 		1B5DF8642DEB4502F4DA220D0A9001E0 /* blue-radio-button-selected-white@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = D03C04790489E971700B6631A4290D31 /* blue-radio-button-selected-white@2x.png */; };
 		20454952E50A4B4F3D6ECDD29C1699C6 /* TableUIUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C3E7E36E3151983394137A24599FBAE /* TableUIUpdater.swift */; };
 		32C1BBC1FBE090BB8D82799099073398 /* SelectSegmentTableViewCell.xib in Sources */ = {isa = PBXBuildFile; fileRef = CE73342EF8F75C076F8828308DEDE6B0 /* SelectSegmentTableViewCell.xib */; };
@@ -103,11 +104,12 @@
 		0932402A4A3A4DDD5EBC4B3B239D77D8 /* SurveyTheme.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SurveyTheme.swift; sourceTree = "<group>"; };
 		09D90708982DA9395534AD770EBA6D84 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		0BA5FC1540096AE864CA7DFEDAE18C33 /* blue-radio-button-deselected-white.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "blue-radio-button-deselected-white.png"; sourceTree = "<group>"; };
-		0E6209D03C52E896C62B770572F90E19 /* Pods_SurveyNative_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_SurveyNative_Example.framework; path = "Pods-SurveyNative_Example.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		0E6209D03C52E896C62B770572F90E19 /* Pods_SurveyNative_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SurveyNative_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		0EA6FD199DC3A70121CBA58E030B0149 /* blue-tick-box-ticked-white.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "blue-tick-box-ticked-white.png"; sourceTree = "<group>"; };
 		114C9F198EE319609D4FE51C62D135D6 /* DatePickerViewController.xib */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file.xib; path = DatePickerViewController.xib; sourceTree = "<group>"; };
 		134112B391F508FB47F64BEB7E4B28E2 /* blue-down-button.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "blue-down-button.png"; sourceTree = "<group>"; };
 		1470C7C3123993658FEF7CA40D42C2FA /* blue-tick-box-not-ticked-white.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "blue-tick-box-not-ticked-white.png"; sourceTree = "<group>"; };
+		173F3C421ED2290500FAA3C8 /* ValidationFailedDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ValidationFailedDelegate.swift; sourceTree = "<group>"; };
 		18801D5C4A630618B4006A7A50A9ED96 /* Pods-SurveyNative_Example-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-SurveyNative_Example-umbrella.h"; sourceTree = "<group>"; };
 		1CCFD44B35F1D9C0E5C3A9E7121E9DDA /* SurveyQuestions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SurveyQuestions.swift; sourceTree = "<group>"; };
 		1CFA0C65165D3181082E734661459E80 /* OptionTableViewCell.xib */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file.xib; path = OptionTableViewCell.xib; sourceTree = "<group>"; };
@@ -117,7 +119,7 @@
 		29D06AF7C266ABC00670D66699B343D8 /* Pods-SurveyNative_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-SurveyNative_Tests.release.xcconfig"; sourceTree = "<group>"; };
 		2A41B6B46BB9A0C79C611AA847151A14 /* Pods-SurveyNative_Tests-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-SurveyNative_Tests-frameworks.sh"; sourceTree = "<group>"; };
 		2BBE067A181628502D2C813F91656D03 /* SurveyAnswerDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SurveyAnswerDelegate.swift; sourceTree = "<group>"; };
-		2D40E8E01309C7942987A017C58500C2 /* SurveyNative.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; path = SurveyNative.modulemap; sourceTree = "<group>"; };
+		2D40E8E01309C7942987A017C58500C2 /* SurveyNative.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = SurveyNative.modulemap; sourceTree = "<group>"; };
 		2E6FA90B8F6C6D2D2EDBDE1E335785C3 /* blue-tick-box-not-ticked-white@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "blue-tick-box-not-ticked-white@2x.png"; sourceTree = "<group>"; };
 		30E08E664E1BFFF2640A1BB6FFE13B93 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		33605DFA1024AD92A5396846994DEDF7 /* OtherOptionTableViewCell.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OtherOptionTableViewCell.swift; sourceTree = "<group>"; };
@@ -127,7 +129,7 @@
 		4C83012372F62682DD38E0A157252A93 /* SubmitButtonTableViewCell.xib */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file.xib; path = SubmitButtonTableViewCell.xib; sourceTree = "<group>"; };
 		4FF220B411FF5ED1C23CDAF360868045 /* ResourceBundle-SurveyNative-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "ResourceBundle-SurveyNative-Info.plist"; sourceTree = "<group>"; };
 		51130A1DE61C5234266ADF82B5C8AE13 /* AddTextFieldTableViewCell.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AddTextFieldTableViewCell.swift; sourceTree = "<group>"; };
-		52A678D6C1B4D836D4ABE947FC089B33 /* Pods-SurveyNative_Example.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; path = "Pods-SurveyNative_Example.modulemap"; sourceTree = "<group>"; };
+		52A678D6C1B4D836D4ABE947FC089B33 /* Pods-SurveyNative_Example.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = "Pods-SurveyNative_Example.modulemap"; sourceTree = "<group>"; };
 		54E8EBE15AE552AD34A8D38C76D4046B /* Pods-SurveyNative_Tests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-SurveyNative_Tests-acknowledgements.plist"; sourceTree = "<group>"; };
 		5B4911C051B1D354885B16FF0E2A99D5 /* TableRowTableViewCell.xib */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file.xib; path = TableRowTableViewCell.xib; sourceTree = "<group>"; };
 		5BAE457D15598C534B475D32DF2EE25D /* Pods-SurveyNative_Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-SurveyNative_Example.release.xcconfig"; sourceTree = "<group>"; };
@@ -149,12 +151,12 @@
 		7FB274F52DCBD9EFA40A707D12B95428 /* YearPickerTableViewCell.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = YearPickerTableViewCell.swift; sourceTree = "<group>"; };
 		810E17C7C6B45497F27689ED01B68514 /* TableRowHeaderTableViewCell.xib */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file.xib; path = TableRowHeaderTableViewCell.xib; sourceTree = "<group>"; };
 		8320C1731CAF10D6C86745C883C38967 /* Pods-SurveyNative_Tests-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-SurveyNative_Tests-umbrella.h"; sourceTree = "<group>"; };
-		8DB4B3D1CF721AA47DF55EC67932E89B /* SurveyNative.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; name = SurveyNative.bundle; path = SurveyNative.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
+		8DB4B3D1CF721AA47DF55EC67932E89B /* SurveyNative.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SurveyNative.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
 		90A0CC926C90C4633CCBA81B525B21A9 /* Pods-SurveyNative_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-SurveyNative_Example.debug.xcconfig"; sourceTree = "<group>"; };
 		9108F6C4CE749085977C699B399D0E16 /* PickerViewController.xib */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file.xib; path = PickerViewController.xib; sourceTree = "<group>"; };
-		9182C3E8DB3410F4D42FD26F8339AB65 /* Pods_SurveyNative_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_SurveyNative_Tests.framework; path = "Pods-SurveyNative_Tests.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		9182C3E8DB3410F4D42FD26F8339AB65 /* Pods_SurveyNative_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SurveyNative_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		918364A0E846A8B409349497F29C8BFB /* DatePickerViewController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DatePickerViewController.swift; sourceTree = "<group>"; };
-		93A4A3777CF96A4AAC1D13BA6DCCEA73 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		93A4A3777CF96A4AAC1D13BA6DCCEA73 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		9ACDEF2A4628FD9DA66BD4D0861E7444 /* TableViewCellActivating.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TableViewCellActivating.swift; sourceTree = "<group>"; };
 		9C3E7E36E3151983394137A24599FBAE /* TableUIUpdater.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TableUIUpdater.swift; sourceTree = "<group>"; };
 		9D620188B0E9D4601CC4277284A65AB4 /* blue-radio-button-deselected-white@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "blue-radio-button-deselected-white@2x.png"; sourceTree = "<group>"; };
@@ -169,7 +171,7 @@
 		C2A30ABFFA5E8C7384A7B17BC2764444 /* Logger.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
 		C4E955E12C69FC4F5C7304B625E1D29F /* Pods-SurveyNative_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-SurveyNative_Tests.debug.xcconfig"; sourceTree = "<group>"; };
 		CA777EDC4FDA1491F55D500B31AAB6AB /* TextFieldTableViewCell.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TextFieldTableViewCell.swift; sourceTree = "<group>"; };
-		CC2978A9A20DF759C96CC4885D7B9DA9 /* Pods-SurveyNative_Tests.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; path = "Pods-SurveyNative_Tests.modulemap"; sourceTree = "<group>"; };
+		CC2978A9A20DF759C96CC4885D7B9DA9 /* Pods-SurveyNative_Tests.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = "Pods-SurveyNative_Tests.modulemap"; sourceTree = "<group>"; };
 		CE73342EF8F75C076F8828308DEDE6B0 /* SelectSegmentTableViewCell.xib */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file.xib; path = SelectSegmentTableViewCell.xib; sourceTree = "<group>"; };
 		D03C04790489E971700B6631A4290D31 /* blue-radio-button-selected-white@2x.png */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = image.png; path = "blue-radio-button-selected-white@2x.png"; sourceTree = "<group>"; };
 		D04F1701B19CE7D27E521237C8000409 /* TableCellDataDelegate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TableCellDataDelegate.swift; sourceTree = "<group>"; };
@@ -182,7 +184,7 @@
 		F34E3FAAC45DBCDC20758968CA7B98A8 /* Pods-SurveyNative_Tests-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-SurveyNative_Tests-resources.sh"; sourceTree = "<group>"; };
 		F387F892D5436E82C08E4106EE28C98F /* Pods-SurveyNative_Example-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-SurveyNative_Example-dummy.m"; sourceTree = "<group>"; };
 		F7A26C0283878506B53233B07A6F1F40 /* Pods-SurveyNative_Example-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-SurveyNative_Example-acknowledgements.markdown"; sourceTree = "<group>"; };
-		FA06EEBC9D5C4D9F1982DB757DF1D9D6 /* SurveyNative.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = SurveyNative.framework; path = SurveyNative.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		FA06EEBC9D5C4D9F1982DB757DF1D9D6 /* SurveyNative.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SurveyNative.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		FB23E7E7C2E780114DDA670BFC4E44E3 /* DynamicLabelTextFieldTableViewCell.xib */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = file.xib; path = DynamicLabelTextFieldTableViewCell.xib; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -225,6 +227,7 @@
 			isa = PBXGroup;
 			children = (
 				7B3504ADAC201B9A87669B2721CDCB49 /* CustomConditionDelegate.swift */,
+				173F3C421ED2290500FAA3C8 /* ValidationFailedDelegate.swift */,
 				6D0A760DEB54F8CBEBB813E81A219B78 /* DefaultSurveyTheme.swift */,
 				6A850EE5E1E4B95B0A16344D01756BDD /* DefaultTableCellDataDelegate.swift */,
 				C2A30ABFFA5E8C7384A7B17BC2764444 /* Logger.swift */,
@@ -239,7 +242,6 @@
 				9C3E7E36E3151983394137A24599FBAE /* TableUIUpdater.swift */,
 				6B28FCF85E5D01567B27D0C8105EB97F /* TableViewCells */,
 			);
-			name = Classes;
 			path = Classes;
 			sourceTree = "<group>";
 		};
@@ -266,7 +268,6 @@
 				0EA6FD199DC3A70121CBA58E030B0149 /* blue-tick-box-ticked-white.png */,
 				B179999695ED92EE4DA6E351D2C69E37 /* blue-tick-box-ticked-white@2x.png */,
 			);
-			name = Assets;
 			path = Assets;
 			sourceTree = "<group>";
 		};
@@ -302,7 +303,6 @@
 				A1CDC47A38F4253A2357C8FACAC2DF44 /* TextFieldTableViewCell.xib */,
 				7FB274F52DCBD9EFA40A707D12B95428 /* YearPickerTableViewCell.swift */,
 			);
-			name = TableViewCells;
 			path = TableViewCells;
 			sourceTree = "<group>";
 		};
@@ -322,7 +322,6 @@
 			children = (
 				C28492D8FE3F2DD133C3EC0D53091E9E /* TableViewCells */,
 			);
-			name = Classes;
 			path = Classes;
 			sourceTree = "<group>";
 		};
@@ -343,7 +342,6 @@
 				583C17512D69BF9D3353DD4FEC6E03B9 /* Assets */,
 				714873E511BCA692D3B126605EC93A5E /* Classes */,
 			);
-			name = SurveyNative;
 			path = SurveyNative;
 			sourceTree = "<group>";
 		};
@@ -370,7 +368,6 @@
 			isa = PBXGroup;
 			children = (
 			);
-			name = TableViewCells;
 			path = TableViewCells;
 			sourceTree = "<group>";
 		};
@@ -428,7 +425,6 @@
 			children = (
 				1738CD87BBB45CA5785B60F848987815 /* Classes */,
 			);
-			name = SurveyNative;
 			path = SurveyNative;
 			sourceTree = "<group>";
 		};
@@ -567,6 +563,11 @@
 			attributes = {
 				LastSwiftUpdateCheck = 0830;
 				LastUpgradeCheck = 0700;
+				TargetAttributes = {
+					71F74C42CE91F8AEB22C2E281A26F2D5 = {
+						LastSwiftMigration = 0830;
+					};
+				};
 			};
 			buildConfigurationList = 2D8E8EC45A3A1A1D94AE762CB5028504 /* Build configuration list for PBXProject "Pods" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -650,6 +651,7 @@
 			files = (
 				C9564FCFFA43DDA42E4CB298286AEDB3 /* AddTextFieldTableViewCell.swift in Sources */,
 				6BAA2ACC75F8766F49086A3F05A4EE02 /* AddTextFieldTableViewCell.xib in Sources */,
+				173F3C441ED2290E00FAA3C8 /* ValidationFailedDelegate.swift in Sources */,
 				81D2705ABC1A0AF96995C431A45B6892 /* CustomConditionDelegate.swift in Sources */,
 				F4EDC80CFD20909EC2D261E447B6FEEF /* DatePickerTableViewCell.swift in Sources */,
 				BA766F9ADBE41857210AA341103E2724 /* DatePickerViewController.swift in Sources */,
@@ -723,6 +725,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 5BAE457D15598C534B475D32DF2EE25D /* Pods-SurveyNative_Example.release.xcconfig */;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
@@ -994,6 +997,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 90A0CC926C90C4633CCBA81B525B21A9 /* Pods-SurveyNative_Example.debug.xcconfig */;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";

--- a/Example/SurveyNative/ExampleQuestions.json
+++ b/Example/SurveyNative/ExampleQuestions.json
@@ -19,10 +19,10 @@
       "id": "birthyear",
       "question": "Enter the year of your birth.",
       "question_type": "year_picker",
-      "max_year" : "current_year",
-      "num_years" : "125",
-      "initial_year" : "1990",
-      "sort_order" : "DESC"
+      "max_year": "current_year",
+      "num_years": "125",
+      "initial_year": "1990",
+      "sort_order": "DESC"
     },
     {
       "id": "sports",
@@ -98,9 +98,15 @@
         "No"
       ],
       "show_if": {
-        "ids": ["age", "birthyear"],
-        "operation" : "custom",
-        "extra": {"id": "check_age", "wiggle_room": 1}
+        "ids": [
+          "age",
+          "birthyear"
+        ],
+        "operation": "custom",
+        "extra": {
+          "id": "check_age",
+          "wiggle_room": 1
+        }
       }
     },
     {
@@ -145,8 +151,8 @@
       ],
       "show_if": {
         "id": "music_types",
-        "operation" : "contains",
-        "value" : "Pop"
+        "operation": "contains",
+        "value": "Pop"
       }
     },
     {
@@ -168,7 +174,33 @@
           "metric"
         ]
       },
-      "input_type": "number"
+      "input_type": "number",
+      "validations": [
+        {
+          "for_label": "Feet",
+          "operation": "greater than",
+          "value": 3,
+          "on_fail_message": "Height must be at least 4 feet"
+        },
+        {
+          "for_label": "Feet",
+          "operation": "less than",
+          "value": 10,
+          "on_fail_message": "Height must be less than 10 feet"
+        },
+        {
+          "for_label": "Centimeters",
+          "operation": "greater than",
+          "value": 100,
+          "on_fail_message": "Height must be at least 100cm"
+        },
+        {
+          "for_label": "Centimeters",
+          "operation": "less than",
+          "value": 250,
+          "on_fail_message": "Weight must be less than 250cm"
+        }
+      ]
     },
     {
       "id": "weight",
@@ -186,6 +218,38 @@
           "metric"
         ]
       },
+      "validations": [
+        {
+          "for_label": "Kilograms",
+          "operation": "greater than",
+          "value": 35,
+          "on_fail_message": "Weight must be at least 35kg"
+        },
+        {
+          "for_label": "Kilograms",
+          "operation": "less than",
+          "value": 635,
+          "on_fail_message": "Weight must be less than 645kg"
+        },
+        {
+          "for_label": "Kilograms",
+          "operation": "greater than",
+          "value": 35,
+          "on_fail_message": "Weight must be at least 35kg"
+        },
+        {
+          "for_label": "Pounds",
+          "operation": "greater than",
+          "value": 78,
+          "on_fail_message": "Weight must be at least 78lb"
+        },
+        {
+          "for_label": "Pounds",
+          "operation": "less than",
+          "value": 1400,
+          "on_fail_message": "Weight must be less than 1,400lb"
+        }
+      ],
       "input_type": "number"
     },
     {
@@ -288,24 +352,26 @@
       "header": "Question 12",
       "question": "What is was the best day of the last year?",
       "question_type": "date_picker",
-      "date" : "current_date",
-      "max_date" : "current_date",
-      "date_diff" : { "year" : -1 }
+      "date": "current_date",
+      "max_date": "current_date",
+      "date_diff": {
+        "year": -1
+      }
     },
     {
-      "id":"pets",
+      "id": "pets",
       "header": "Question 12",
       "question": "How many pets do you have?",
       "question_type": "multi_text_field",
       "fields": [
-         {
-            "label" : "Dogs",
-            "input_type" : "number"
-         },
-         {
-            "label" : "Cats",
-            "input_type" : "number"
-         }
+        {
+          "label": "Dogs",
+          "input_type": "number"
+        },
+        {
+          "label": "Cats",
+          "input_type": "number"
+        }
       ]
     }
   ],
@@ -313,5 +379,5 @@
     "button_title": "Submit Answers",
     "url": "https://www.example.com"
   },
-  "auto_focus_text" : true
+  "auto_focus_text": true
 }

--- a/Example/SurveyNative/ExampleQuestions.json
+++ b/Example/SurveyNative/ExampleQuestions.json
@@ -62,7 +62,7 @@
           "on_fail_message": "Age must be at least 10"
         },
         {
-          "operation": "less than",
+          "operation": "less than or equal to",
           "value": 80,
           "on_fail_message": "You must be 80 or younger"
         }
@@ -90,7 +90,33 @@
       ]
     },
     {
+      "id": "felt_like_adult",
+      "header": "Question 6",
+      "question": "How old were you when you felt like an adult?",
+      "question_type": "single_select",
+      "options": [
+        {
+          "title": "Years old",
+          "type": "number",
+          "validations": [
+            {
+              "operation": "greater than",
+              "value": 5,
+              "on_fail_message": "Age must be at least 10"
+            },
+            {
+              "operation": "less than or equal to",
+              "answer_to_question_id": "age",
+              "on_fail_message": "Greater than your current age"
+            }
+          ]
+        },
+        "Don't know"
+      ]
+    },
+    {
       "id": "lie_about_age",
+      "header": "Question 7",
       "question": "Do you ever lie about your age?",
       "question_type": "single_select",
       "options": [
@@ -111,7 +137,7 @@
     },
     {
       "id": "like_music",
-      "header": "Question 5",
+      "header": "Question 8",
       "question": "Do you like music?",
       "question_type": "single_select",
       "options": [
@@ -121,7 +147,7 @@
     },
     {
       "id": "music_types",
-      "header": "Question 6",
+      "header": "Question 9",
       "question": "What types of music do you like?",
       "question_type": "multi_select",
       "options": [
@@ -142,7 +168,7 @@
     },
     {
       "id": "go_to_concerts",
-      "header": "Question 5",
+      "header": "Question 10",
       "question": "Do you go to concerts?",
       "question_type": "single_select",
       "options": [
@@ -157,7 +183,7 @@
     },
     {
       "id": "height",
-      "header": "Question 7",
+      "header": "Question 11",
       "question": "How tall are you?",
       "question_type": "dynamic_label_text_field",
       "label_options": [
@@ -204,7 +230,7 @@
     },
     {
       "id": "weight",
-      "header": "Question 6",
+      "header": "Question 12",
       "question": "How much do you weigh?",
       "question_type": "dynamic_label_text_field",
       "label_options": [
@@ -248,7 +274,7 @@
     },
     {
       "id": "happiness",
-      "header": "Question 9",
+      "header": "Question 13",
       "question": "How happy are you?",
       "question_type": "segment_select",
       "low_tag": "1. Not happy",
@@ -265,7 +291,7 @@
     },
     {
       "id": "weekend_activities",
-      "header": "Question 10",
+      "header": "Question 14",
       "question": "On the weekends, do you:",
       "question_type": "table_select",
       "options": [
@@ -294,7 +320,7 @@
     },
     {
       "id": "prefer_tv_books",
-      "header": "Question 11",
+      "header": "Question 15",
       "question": "Do you like to read the book of the movie before you see it?",
       "question_type": "single_select",
       "options": [
@@ -343,7 +369,7 @@
     },
     {
       "id": "date",
-      "header": "Question 12",
+      "header": "Question 16",
       "question": "What is was the best day of the last year?",
       "question_type": "date_picker",
       "date": "current_date",
@@ -354,7 +380,7 @@
     },
     {
       "id": "pets",
-      "header": "Question 12",
+      "header": "Question 17",
       "question": "How many pets do you have?",
       "question_type": "multi_text_field",
       "fields": [

--- a/Example/SurveyNative/ExampleQuestions.json
+++ b/Example/SurveyNative/ExampleQuestions.json
@@ -232,12 +232,6 @@
           "on_fail_message": "Weight must be less than 645kg"
         },
         {
-          "for_label": "Kilograms",
-          "operation": "greater than",
-          "value": 35,
-          "on_fail_message": "Weight must be at least 35kg"
-        },
-        {
           "for_label": "Pounds",
           "operation": "greater than",
           "value": 78,

--- a/Example/SurveyNative/ExampleQuestions.json
+++ b/Example/SurveyNative/ExampleQuestions.json
@@ -69,6 +69,27 @@
       ]
     },
     {
+      "id": "age_of_first_kiss",
+      "header": "Question 5",
+      "question": "Age when you had your first kiss?",
+      "question_type": "single_text_field",
+      "label": "Years",
+      "input_type": "number",
+      "max_chars": "2",
+      "validations": [
+        {
+          "operation": "greater than",
+          "value": 8,
+          "on_fail_message": "That doesn't count (older than 8)"
+        },
+        {
+          "operation": "less than or equal to",
+          "answer_to_question_id": "age",
+          "on_fail_message": "Time machines not invented yet"
+        }
+      ]
+    },
+    {
       "id": "lie_about_age",
       "question": "Do you ever lie about your age?",
       "question_type": "single_select",

--- a/Example/SurveyNative/ExampleQuestions.json
+++ b/Example/SurveyNative/ExampleQuestions.json
@@ -54,7 +54,19 @@
       "question_type": "single_text_field",
       "label": "Years",
       "input_type": "number",
-      "max_chars" : "2",
+      "max_chars": "2",
+      "validations": [
+        {
+          "operation": "greater than",
+          "value": 10,
+          "on_fail_message": "Age must be at least 10"
+        },
+        {
+          "operation": "less than",
+          "value": 80,
+          "on_fail_message": "You must be 80 or younger"
+        }
+      ]
     },
     {
       "id": "lie_about_age",

--- a/Example/SurveyNative/MyViewController.swift
+++ b/Example/SurveyNative/MyViewController.swift
@@ -9,12 +9,13 @@
 import UIKit
 import SurveyNative
 
-class MyViewController: SurveyViewController, SurveyAnswerDelegate, CustomConditionDelegate {
+class MyViewController: SurveyViewController, SurveyAnswerDelegate, CustomConditionDelegate, ValidationFailedDelegate {
    
    override func viewDidLoad() {
       super.viewDidLoad()
       self.setSurveyAnswerDelegate(self)
       self.setCustomConditionDelegate(self)
+      self.setValidationFailedDelegate(self)
    }
    
    override func surveyJsonFile() -> String {
@@ -48,6 +49,12 @@ class MyViewController: SurveyViewController, SurveyAnswerDelegate, CustomCondit
          Logger.log("Unknown custom condition check: \(id)")
          return false
       }
+   }
+
+   func validationFailed(message: String) {
+      let alert = UIAlertController(title: nil, message: message, preferredStyle: UIAlertControllerStyle.alert)
+      alert.addAction(UIAlertAction(title: "OK", style: UIAlertActionStyle.default, handler: nil))
+      self.present(alert, animated: true, completion: nil)
    }
 }
 

--- a/README.md
+++ b/README.md
@@ -57,10 +57,11 @@ The expected input is an array of `questions` and a `submit` object, detailing h
 
   - `max_chars` (_String_): Options for `single_text_field` and `multi_text_field` question_types.  Determines the max number of characters the user may enter.
 
-  - `validations` (_Array of Dictionaries_): Optional for `single_text_field` question_type. Check value meets the validations when `Next` tapped. If not `validationFailed(message: String)` is called on your `ValidationFailedDelegate`. Validations consist of attributes:
+  - `validations` (_Array of Dictionaries_): Optional for `single_text_field` and `dynamic_label_text_field` question_types. Check value meets the validations when `Next` tapped. If not `validationFailed(message: String)` is called on your `ValidationFailedDelegate`. Validations consist of attributes:
   	-  `operation`
   	-  `value` or `answer_to_question_id`
   	-  `on_fail_message`
+  	-  `for_label` (only used for `dynamic_label_text_field`)
   	
   	Supported operations:
 
@@ -279,7 +280,40 @@ The submit object (a peer to `questions`) requires only two keys, `button_title`
     ],
     "Centimeters"
   ],
-  "input_type": "number"
+  "options_metadata": {
+    "id": "unit_system",
+    "types": [
+      "imperial",
+      "metric"
+    ]
+  },
+  "input_type": "number",
+  "validations": [
+    {
+      "for_label": "Feet",
+      "operation": "greater than",
+      "value": 3,
+      "on_fail_message": "Height must be at least 4 feet"
+    },
+    {
+      "for_label": "Feet",
+      "operation": "less than",
+      "value": 10,
+      "on_fail_message": "Height must be less than 10 feet"
+    },
+    {
+      "for_label": "Centimeters",
+      "operation": "greater than",
+      "value": 100,
+      "on_fail_message": "Height must be at least 100cm"
+    },
+    {
+      "for_label": "Centimeters",
+      "operation": "less than",
+      "value": 250,
+      "on_fail_message": "Weight must be less than 250cm"
+    }
+  ]
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -54,11 +54,20 @@ The expected input is an array of `questions` and a `submit` object, detailing h
   - `label_options` (_Array containing Strings or String Arrays_): Required for `dynamic_label_text_field`.
 
   - `input_type` (_String_): Optional for `single_text_field`, `dynamic_label_text_field`, `add_text_field` question_types. Can be set to `number` to change the default keyboard to the number keyboard for the text field(s).
-  
+
   - `max_chars` (_String_): Options for `single_text_field` and `multi_text_field` question_types.  Determines the max number of characters the user may enter.
 
+  - `validations` (_Array of Dictionaries_): Optional for `single_text_field` question_type. Check value meets the validations when `Next` tapped. If not `validationFailed(message: String)` is called on your `ValidationFailedDelegate`. Validations consist of an `operation`, `value` and `on_fail_message`. Supported operations:
+
+    - `equals`
+    - `not equals`
+    - `greater than`
+    - `greater than or equal to`
+    - `less than`
+    - `less than or equal to`
+
   - `values` (_Array of String_): Required for `segment_select` question_type. These are the values the user will choose between.
-  
+
   - `fields` (_Array of Dictionaries_): Required for `multi_text_field` question_type.  Each dictionary must contain a `label` key and an `input_type` key.
 
   - `low_tag` (_String_): Optional for `segment_select` question_type. This is a label for the lowest (first) value.
@@ -66,25 +75,26 @@ The expected input is an array of `questions` and a `submit` object, detailing h
   - `high_tag` (_String_): Optional for `segment_select` question_type. This is a label for the highest (last) value.
 
   - `table_questions` (_Array of table questions_): Required for `table_select` question_type. Each table question should have a `title` and an `id` attribute.
-  
+
   - `min_year` (_String_): Optional for `year_picker` question_type.  Can be an integer or "current_year". See [More about Year Picker](#more-about-year-picker) below for more info.
-  
+
   - `max_year` (_String_): Optional for `year_picker` question_type.  Can be an integer or "current_year". See [More about Year Picker](#more-about-year-picker) below for more info.
-  
+
   - `num_years` (_String_): Optional for `year_picker` question_type.  See [More about Year Picker](#more-about-year-picker) below for more info.
-  
+
   - `initial_year` (_String_): Optional for `year_picker` question_type.  If set, this year will be selected when the picker is first opened.
-  
+
   - `sort_order` (_String_): Optional for `year_picker` question_type.  May be "ASC" (ascending) or "DESC" (descending).  Defaults to "ASC".
-  
+
   - `date` (_String in YYYY-MM-dd format or "current_date"_): Optional for `date_picker` question_type.  If specified, the picker will initially be set to this value (unless the question is already answered, in which case it will be set to the previous answer).  If unset, defaults to the current date.
-  
+
   - `max_date` (_String in YYYY-MM-dd format or "current_date"_): Optional for `date_picker` question_type.  If specified, the picker will not allow the user to choose a date later than this.  If min_date is specified and min_date > max_date, both values will be ignored.
-  
+
   - `min_date` (_String in YYYY-MM-dd format or "current_date"_): Optional for `date_picker` question_type.  If specified, the picker will not allow the user to choose a date earlier than this.  If min_date is specified and min_date > max_date, both values will be ignored.
-  
+
   - `date_diff` (_Dictionary of String to Int values_): Optional for `date_picker` question_type.  Valid keys are `day`, `month`, and `year`.  Only takes effect if exactly one of `min_date` and `max_date` is set.  The unset min/max value will be set by adding the affect of this to the set min/max value.  `date_diff` should be overall positive if `min_date` is set and negative if `max_date` is set.  If `date_diff` is set such that `min_date` > `max_date`, both values will be ignored.
-  
+
+
 #### More about Year Picker
 
 You only need to specify two of `min_year`, `max_year`, and `num_years`.  The missing values will be calculated from what is provided.  If all three are provided, the `num_years` value will be ignored.  If less than two values are provided, we'll guess reasonable values for the missing ones.
@@ -116,7 +126,7 @@ Whether a question is shown or hidden is dependent on the `show_if` key. If the 
   - `operation` (_String_): Required. Can be `or` or `and`. If you need a combination, you should be able to use nesting to get it.
 
   - `subconditions` (_Array of Simple Conditions or Decision Trees_): Required.
-  
+
 #### Custom Conditions
 
 If these options are inadequate, you can set a _CustomConditionDelegate_ and use it to make the show/hide decision.
@@ -124,9 +134,9 @@ If these options are inadequate, you can set a _CustomConditionDelegate_ and use
   - `ids` (_Array of Strings_): Required.  Must be non-empty. These are the ids for questions the your delegate needs the answers to in order to perform it's show/hide calculation.  Your delegate will be called as soon as any of the questions are answered, so you may have nil data for one or more answers.
 
   - `operation` (_String_): Required. Should be set to 'custom'.
-  
+
   - `extra` (_Dictionary with String keys_): Optional. This will be passed to the _isConditionMet_ method of your _CustomConditionDelegate_.
-  
+
 ### Submit
 
 The submit object (a peer to `questions`) requires only two keys, `button_title` and `url`. Both are required strings.
@@ -212,7 +222,19 @@ The submit object (a peer to `questions`) requires only two keys, `button_title`
   "question_type": "single_text_field",
   "label": "Years",
   "input_type": "number",
-  "max_chars": "2"
+  "max_chars": "2",
+  "validations": [
+    {
+      "operation": "greater than",
+      "value": 10,
+      "on_fail_message": "Age must be at least 10"
+    },
+    {
+      "operation": "less than",
+      "value": 80,
+      "on_fail_message": "You must be 80 or younger"
+    }
+  ]
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,12 @@ The expected input is an array of `questions` and a `submit` object, detailing h
 
   - `max_chars` (_String_): Options for `single_text_field` and `multi_text_field` question_types.  Determines the max number of characters the user may enter.
 
-  - `validations` (_Array of Dictionaries_): Optional for `single_text_field` question_type. Check value meets the validations when `Next` tapped. If not `validationFailed(message: String)` is called on your `ValidationFailedDelegate`. Validations consist of an `operation`, `value` and `on_fail_message`. Supported operations:
+  - `validations` (_Array of Dictionaries_): Optional for `single_text_field` question_type. Check value meets the validations when `Next` tapped. If not `validationFailed(message: String)` is called on your `ValidationFailedDelegate`. Validations consist of attributes:
+  	-  `operation`
+  	-  `value` or `answer_to_question_id`
+  	-  `on_fail_message`
+  	
+  	Supported operations:
 
     - `equals`
     - `not equals`

--- a/SurveyNative/Classes/DefaultTableCellDataDelegate.swift
+++ b/SurveyNative/Classes/DefaultTableCellDataDelegate.swift
@@ -34,7 +34,11 @@ open class DefaultTableCellDataDelegate : NSObject, TableCellDataDelegate {
    public func validationFailed(message : String) {
       surveyQuestions.validationFailed(message: message)
    }
-   
+
+   public func answerForQuestion(id: String) -> Any {
+      return surveyQuestions.answer(for: id)!
+   }
+
    public func updateUI() {
       self.tableView.beginUpdates()
       self.tableView.endUpdates()

--- a/SurveyNative/Classes/DefaultTableCellDataDelegate.swift
+++ b/SurveyNative/Classes/DefaultTableCellDataDelegate.swift
@@ -30,6 +30,10 @@ open class DefaultTableCellDataDelegate : NSObject, TableCellDataDelegate {
    public func markFinished(updateId: String) {
       TableUIUpdater.updateTable(surveyQuestions.markFinished(updateId: updateId), tableView: tableView, autoFocus: surveyQuestions.autoFocusText)
    }
+
+   public func validationFailed(message : String) {
+      surveyQuestions.validationFailed(message: message)
+   }
    
    public func updateUI() {
       self.tableView.beginUpdates()

--- a/SurveyNative/Classes/SurveyDataSource.swift
+++ b/SurveyNative/Classes/SurveyDataSource.swift
@@ -111,6 +111,7 @@ open class SurveyDataSource : NSObject, UITableViewDataSource {
          (tableCell as! DynamicLabelTextFieldTableViewCell).optionsMetadata = surveyQuestions.optionsMetadata(for: indexPath)
          (tableCell as! DynamicLabelTextFieldTableViewCell).currentValue = surveyQuestions.answer(for: indexPath) as? [String : String]
          (tableCell as! DynamicLabelTextFieldTableViewCell).keyboardType = surveyQuestions.keyboardType(for: indexPath)
+         (tableCell as! DynamicLabelTextFieldTableViewCell).validations = surveyQuestions.validations(for: indexPath)
       case "add_text_field":
          (tableCell as! AddTextFieldTableViewCell).dataDelegate = self.tableCellDataDelegate
          (tableCell as! AddTextFieldTableViewCell).updateId = surveyQuestions.id(for: indexPath)

--- a/SurveyNative/Classes/SurveyDataSource.swift
+++ b/SurveyNative/Classes/SurveyDataSource.swift
@@ -9,72 +9,78 @@
 import Foundation
 
 open class SurveyDataSource : NSObject, UITableViewDataSource {
-   
+
    var surveyQuestions : SurveyQuestions
    var surveyTheme : SurveyTheme
    var tableCellDataDelegate : TableCellDataDelegate
    weak var presentationDelegate : UIViewController?
-   
+
    public init(_ surveyQuestions : SurveyQuestions, surveyTheme : SurveyTheme, tableCellDataDelegate : TableCellDataDelegate, presentationDelegate: UIViewController) {
       self.surveyQuestions = surveyQuestions
       self.surveyTheme = surveyTheme
       self.tableCellDataDelegate = tableCellDataDelegate
       self.presentationDelegate = presentationDelegate
    }
-   
+
    open func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
       let cellIdentifier = surveyQuestions.type(for: indexPath)
       let tableCell = tableView.dequeueReusableCell(withIdentifier: cellIdentifier, for: indexPath)
       return configure(tableCell, for: cellIdentifier, indexPath: indexPath)
    }
-   
+
    func configure(_ tableCell : UITableViewCell, for cellIdentifier: String, indexPath: IndexPath) -> UITableViewCell {
       switch cellIdentifier {
       case "year_picker":
-         (tableCell as! YearPickerTableViewCell).presentationDelegate = self.presentationDelegate
-         (tableCell as! YearPickerTableViewCell).dataDelegate = self.tableCellDataDelegate
-         (tableCell as! YearPickerTableViewCell).updateId = surveyQuestions.id(for: indexPath)
-         (tableCell as! YearPickerTableViewCell).selectedYear = surveyQuestions.answer(for: indexPath) as! String?
-         (tableCell as! YearPickerTableViewCell).setYearRange(minYear: surveyQuestions.minYear(for: indexPath), maxYear: surveyQuestions.maxYear(for: indexPath), numYears: surveyQuestions.numYears(for: indexPath), sortOrder: surveyQuestions.yearSortOrder(for: indexPath))
-         (tableCell as! YearPickerTableViewCell).initialYear = surveyQuestions.initialYear(for: indexPath)
+         let cell = (tableCell as! YearPickerTableViewCell)
+         cell.presentationDelegate = self.presentationDelegate
+         cell.dataDelegate = self.tableCellDataDelegate
+         cell.updateId = surveyQuestions.id(for: indexPath)
+         cell.selectedYear = surveyQuestions.answer(for: indexPath) as! String?
+         cell.setYearRange(minYear: surveyQuestions.minYear(for: indexPath), maxYear: surveyQuestions.maxYear(for: indexPath), numYears: surveyQuestions.numYears(for: indexPath), sortOrder: surveyQuestions.yearSortOrder(for: indexPath))
+         cell.initialYear = surveyQuestions.initialYear(for: indexPath)
       case "date_picker":
-         (tableCell as! DatePickerTableViewCell).presentationDelegate = self.presentationDelegate
-         (tableCell as! DatePickerTableViewCell).dataDelegate = self.tableCellDataDelegate
-         (tableCell as! DatePickerTableViewCell).updateId = surveyQuestions.id(for: indexPath)
-         (tableCell as! DatePickerTableViewCell).setDateRange(currentDate: surveyQuestions.date(for: indexPath), minDate: surveyQuestions.minDate(for: indexPath), maxDate: surveyQuestions.maxDate(for: indexPath), dateDiff: surveyQuestions.dateDiff(for: indexPath))
-         (tableCell as! DatePickerTableViewCell).selectedDateStr = surveyQuestions.answer(for: indexPath) as! String?
+         let cell = (tableCell as! DatePickerTableViewCell)
+         cell.presentationDelegate = self.presentationDelegate
+         cell.dataDelegate = self.tableCellDataDelegate
+         cell.updateId = surveyQuestions.id(for: indexPath)
+         cell.setDateRange(currentDate: surveyQuestions.date(for: indexPath), minDate: surveyQuestions.minDate(for: indexPath), maxDate: surveyQuestions.maxDate(for: indexPath), dateDiff: surveyQuestions.dateDiff(for: indexPath))
+         cell.selectedDateStr = surveyQuestions.answer(for: indexPath) as! String?
       case "option":
-         (tableCell as! OptionTableViewCell).optionLabel?.text = surveyQuestions.text(for: indexPath)
-         (tableCell as! OptionTableViewCell).surveyTheme = self.surveyTheme
-         (tableCell as! OptionTableViewCell).setSelectionState(surveyQuestions.isOptionSelected(indexPath))
-         (tableCell as! OptionTableViewCell).isSingleSelection = !surveyQuestions.isMultiSelect(indexPath)
+         let cell = (tableCell as! OptionTableViewCell)
+         cell.optionLabel?.text = surveyQuestions.text(for: indexPath)
+         cell.surveyTheme = self.surveyTheme
+         cell.setSelectionState(surveyQuestions.isOptionSelected(indexPath))
+         cell.isSingleSelection = !surveyQuestions.isMultiSelect(indexPath)
       case "other_option":
-         (tableCell as! OtherOptionTableViewCell).updateId = nil
-         (tableCell as! OtherOptionTableViewCell).dataDelegate = self.tableCellDataDelegate
-         (tableCell as! OtherOptionTableViewCell).surveyTheme = self.surveyTheme
-         (tableCell as! OtherOptionTableViewCell).label?.text = surveyQuestions.text(for: indexPath)
-         (tableCell as! OtherOptionTableViewCell).isSingleSelection = !surveyQuestions.isMultiSelect(indexPath)
+         let cell = (tableCell as! OtherOptionTableViewCell)
+         cell.updateId = nil
+         cell.dataDelegate = self.tableCellDataDelegate
+         cell.surveyTheme = self.surveyTheme
+         cell.label?.text = surveyQuestions.text(for: indexPath)
+         cell.isSingleSelection = !surveyQuestions.isMultiSelect(indexPath)
          let selected = surveyQuestions.isOptionSelected(indexPath)
-         (tableCell as! OtherOptionTableViewCell).isSelectedOption = selected
+         cell.isSelectedOption = selected
          if selected {
-            (tableCell as! OtherOptionTableViewCell).optionText = surveyQuestions.otherAnswer(for: indexPath)
-            (tableCell as! OtherOptionTableViewCell).setSelectionState(true)
+            cell.optionText = surveyQuestions.otherAnswer(for: indexPath)
+            cell.setSelectionState(true)
          } else {
-            (tableCell as! OtherOptionTableViewCell).optionText = ""
+            cell.optionText = ""
          }
-         (tableCell as! OtherOptionTableViewCell).textField?.keyboardType = surveyQuestions.keyboardType(for: indexPath)
-         (tableCell as! OtherOptionTableViewCell).shouldShowNextButton = surveyQuestions.showNextButton(for: indexPath)
-         (tableCell as! OtherOptionTableViewCell).updateId = surveyQuestions.id(for: indexPath)
+         cell.textField?.keyboardType = surveyQuestions.keyboardType(for: indexPath)
+         cell.shouldShowNextButton = surveyQuestions.showNextButton(for: indexPath)
+         cell.updateId = surveyQuestions.id(for: indexPath)
+         cell.validations = surveyQuestions.validations(for: indexPath)
       case "text_field":
-         (tableCell as! TextFieldTableViewCell).updateId = nil
-         (tableCell as! TextFieldTableViewCell).dataDelegate = self.tableCellDataDelegate
-         (tableCell as! TextFieldTableViewCell).textFieldLabel?.text = surveyQuestions.text(for: indexPath)
-         (tableCell as! TextFieldTableViewCell).textField?.keyboardType = surveyQuestions.keyboardType(for: indexPath)
-         (tableCell as! TextFieldTableViewCell).maxCharacters = surveyQuestions.maxChars(for: indexPath)
-         (tableCell as! TextFieldTableViewCell).validations = surveyQuestions.validations(for: indexPath)
-         (tableCell as! TextFieldTableViewCell).textFieldText = surveyQuestions.partialAnswer(for: indexPath) as! String?
-         (tableCell as! TextFieldTableViewCell).shouldShowNextButton = surveyQuestions.showNextButton(for: indexPath)
-         (tableCell as! TextFieldTableViewCell).updateId = surveyQuestions.id(for: indexPath)
+         let cell = (tableCell as! TextFieldTableViewCell)
+         cell.updateId = nil
+         cell.dataDelegate = self.tableCellDataDelegate
+         cell.textFieldLabel?.text = surveyQuestions.text(for: indexPath)
+         cell.textField?.keyboardType = surveyQuestions.keyboardType(for: indexPath)
+         cell.maxCharacters = surveyQuestions.maxChars(for: indexPath)
+         cell.validations = surveyQuestions.validations(for: indexPath)
+         cell.textFieldText = surveyQuestions.partialAnswer(for: indexPath) as! String?
+         cell.shouldShowNextButton = surveyQuestions.showNextButton(for: indexPath)
+         cell.updateId = surveyQuestions.id(for: indexPath)
       case "next_button":
          let nextButton = UIButtonWithId(type: UIButtonType.system)
          nextButton.setTitle("Next", for: UIControlState.normal)
@@ -88,40 +94,45 @@ open class SurveyDataSource : NSObject, UITableViewDataSource {
       case "question":
          (tableCell as! DynamicLabelTableViewCell).dynamicLabel?.text = surveyQuestions.text(for: indexPath)
       case "segment_select":
-         (tableCell as! SelectSegmentTableViewCell).updateId = surveyQuestions.id(for: indexPath)
-         (tableCell as! SelectSegmentTableViewCell).dataDelegate = self.tableCellDataDelegate
-         (tableCell as! SelectSegmentTableViewCell).values = surveyQuestions.values(for: indexPath)
+         let cell = (tableCell as! SelectSegmentTableViewCell)
+         cell.updateId = surveyQuestions.id(for: indexPath)
+         cell.dataDelegate = self.tableCellDataDelegate
+         cell.values = surveyQuestions.values(for: indexPath)
          if let answer = surveyQuestions.answer(for: indexPath) as? String {
-            (tableCell as! SelectSegmentTableViewCell).setSelectedValue(answer)
+            cell.setSelectedValue(answer)
          }
-         (tableCell as! SelectSegmentTableViewCell).lowLabel?.text = surveyQuestions.lowTag(for: indexPath)
-         (tableCell as! SelectSegmentTableViewCell).highLabel?.text = surveyQuestions.highTag(for: indexPath)
+         cell.lowLabel?.text = surveyQuestions.lowTag(for: indexPath)
+         cell.highLabel?.text = surveyQuestions.highTag(for: indexPath)
       case "row_header":
          (tableCell as! TableRowHeaderTableViewCell).headers = surveyQuestions.headers(for: indexPath)
       case "row_select":
          let surveyTheme = self.surveyTheme
-         (tableCell as! TableRowTableViewCell).surveyTheme = surveyTheme
-         (tableCell as! TableRowTableViewCell).updateId = surveyQuestions.id(for: indexPath)
-         (tableCell as! TableRowTableViewCell).dataDelegate = self.tableCellDataDelegate
-         (tableCell as! TableRowTableViewCell).headers = surveyQuestions.headers(for: indexPath)!
-         (tableCell as! TableRowTableViewCell).question?.text = surveyQuestions.text(for: indexPath)
-         (tableCell as! TableRowTableViewCell).selectedHeader = surveyQuestions.partialAnswer(for: indexPath) as! String?
+         let cell = (tableCell as! TableRowTableViewCell)
+         cell.surveyTheme = surveyTheme
+         cell.updateId = surveyQuestions.id(for: indexPath)
+         cell.dataDelegate = self.tableCellDataDelegate
+         cell.headers = surveyQuestions.headers(for: indexPath)!
+         cell.question?.text = surveyQuestions.text(for: indexPath)
+         cell.selectedHeader = surveyQuestions.partialAnswer(for: indexPath) as! String?
       case "dynamic_label_text_field":
-         (tableCell as! DynamicLabelTextFieldTableViewCell).dataDelegate = self.tableCellDataDelegate
-         (tableCell as! DynamicLabelTextFieldTableViewCell).updateId = surveyQuestions.id(for: indexPath)
-         (tableCell as! DynamicLabelTextFieldTableViewCell).presentationDelegate = self.presentationDelegate
-         (tableCell as! DynamicLabelTextFieldTableViewCell).labelOptions = surveyQuestions.labelOptions(for: indexPath)
-         (tableCell as! DynamicLabelTextFieldTableViewCell).optionsMetadata = surveyQuestions.optionsMetadata(for: indexPath)
-         (tableCell as! DynamicLabelTextFieldTableViewCell).currentValue = surveyQuestions.answer(for: indexPath) as? [String : String]
-         (tableCell as! DynamicLabelTextFieldTableViewCell).keyboardType = surveyQuestions.keyboardType(for: indexPath)
-         (tableCell as! DynamicLabelTextFieldTableViewCell).validations = surveyQuestions.validations(for: indexPath)
+         let cell = (tableCell as! DynamicLabelTextFieldTableViewCell)
+         cell.dataDelegate = self.tableCellDataDelegate
+         cell.updateId = surveyQuestions.id(for: indexPath)
+         cell.presentationDelegate = self.presentationDelegate
+         cell.labelOptions = surveyQuestions.labelOptions(for: indexPath)
+         cell.optionsMetadata = surveyQuestions.optionsMetadata(for: indexPath)
+         cell.currentValue = surveyQuestions.answer(for: indexPath) as? [String : String]
+         cell.keyboardType = surveyQuestions.keyboardType(for: indexPath)
+         cell.validations = surveyQuestions.validations(for: indexPath)
       case "add_text_field":
-         (tableCell as! AddTextFieldTableViewCell).dataDelegate = self.tableCellDataDelegate
-         (tableCell as! AddTextFieldTableViewCell).updateId = surveyQuestions.id(for: indexPath)
-         (tableCell as! AddTextFieldTableViewCell).currentValues = surveyQuestions.answer(for: indexPath) as? [String]
+         let cell = (tableCell as! AddTextFieldTableViewCell)
+         cell.dataDelegate = self.tableCellDataDelegate
+         cell.updateId = surveyQuestions.id(for: indexPath)
+         cell.currentValues = surveyQuestions.answer(for: indexPath) as? [String]
       case "submit":
-         (tableCell as! SubmitButtonTableViewCell).dataDelegate = self.tableCellDataDelegate
-         (tableCell as! SubmitButtonTableViewCell).submitButton?.setTitle(surveyQuestions.submitTitle(), for: .normal)
+         let cell = (tableCell as! SubmitButtonTableViewCell)
+         cell.dataDelegate = self.tableCellDataDelegate
+         cell.submitButton?.setTitle(surveyQuestions.submitTitle(), for: .normal)
       default:
          tableCell.textLabel?.text = surveyQuestions.text(for: indexPath)
          tableCell.textLabel?.numberOfLines = 0
@@ -130,7 +141,7 @@ open class SurveyDataSource : NSObject, UITableViewDataSource {
       }
       return tableCell
    }
-   
+
    open func numberOfSections(in tableView: UITableView) -> Int {
       return surveyQuestions.numberOfSections()
    }
@@ -138,11 +149,11 @@ open class SurveyDataSource : NSObject, UITableViewDataSource {
    open func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
       return surveyQuestions.numberOfRows(for: section)
    }
-   
+
    open func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
       return surveyQuestions.headerText(section: section)
    }
-   
+
    open func nextButtonTapped(_ sender: UIButton) {
       if let buttonWithId = sender as? UIButtonWithId, let updateId = buttonWithId.updateId {
          self.tableCellDataDelegate.markFinished(updateId: updateId)

--- a/SurveyNative/Classes/SurveyDataSource.swift
+++ b/SurveyNative/Classes/SurveyDataSource.swift
@@ -68,6 +68,7 @@ open class SurveyDataSource : NSObject, UITableViewDataSource {
          (tableCell as! TextFieldTableViewCell).textFieldLabel?.text = surveyQuestions.text(for: indexPath)
          (tableCell as! TextFieldTableViewCell).textField?.keyboardType = surveyQuestions.keyboardType(for: indexPath)
          (tableCell as! TextFieldTableViewCell).maxCharacters = surveyQuestions.maxChars(for: indexPath)
+         (tableCell as! TextFieldTableViewCell).validations = surveyQuestions.validations(for: indexPath)
          (tableCell as! TextFieldTableViewCell).textFieldText = surveyQuestions.partialAnswer(for: indexPath) as! String?
          (tableCell as! TextFieldTableViewCell).shouldShowNextButton = surveyQuestions.showNextButton(for: indexPath)
          (tableCell as! TextFieldTableViewCell).updateId = surveyQuestions.id(for: indexPath)

--- a/SurveyNative/Classes/SurveyQuestions.swift
+++ b/SurveyNative/Classes/SurveyQuestions.swift
@@ -674,16 +674,16 @@ open class SurveyQuestions {
    func optionText(option: AnyHashable) -> String {
       if let title = option as? String {
          return title
-      } else if let optionDict = option as? [String : String] {
-         return optionDict["title"]!
+      } else if let optionDict = option as? [String : Any] {
+         return optionDict["title"] as! String
       } else {
          return ""
       }
    }
    
    func otherOptionType(option: AnyHashable) -> String {
-      if let optionDict = option as? [String : String] {
-         return optionDict["type"]!
+      if let optionDict = option as? [String : Any] {
+         return optionDict["type"] as! String
       } else {
          return ""
       }
@@ -696,7 +696,7 @@ open class SurveyQuestions {
    
    func isOtherOption(for questionPath: QuestionPath) -> Bool {
       let option = self.option(for: questionPath)
-      return (option as? [String : String]) != nil
+      return (option as? [String : Any]) != nil
    }
    
    public func isOptionSelected(_ indexPath: IndexPath) -> Bool {
@@ -806,15 +806,20 @@ open class SurveyQuestions {
    func validations(for indexPath: IndexPath) -> [[String : Any]] {
       let questionPath = self.questionPath(for: indexPath)
       let type = self.type(for: questionPath)
-      if type != "text_field" && type != "dynamic_label_text_field" {
+      if type != "text_field" && type != "dynamic_label_text_field" && type != "other_option" {
          return []
       }
       let question = self.question(for: questionPath)
+
+      if type == "other_option" {
+         let option = self.option(for: questionPath) as! [String : Any]
+         return validations(option)
+      }
       return validations(question)
    }
 
-   func validations(_ textField: [String : Any?]) -> [[String : Any]] {
-      if let validations = textField["validations"] as? [[String : Any]] {
+   func validations(_ question: [String : Any?]) -> [[String : Any]] {
+      if let validations = question["validations"] as? [[String : Any]] {
          return validations
       } else {
          return []

--- a/SurveyNative/Classes/SurveyQuestions.swift
+++ b/SurveyNative/Classes/SurveyQuestions.swift
@@ -806,7 +806,7 @@ open class SurveyQuestions {
    func validations(for indexPath: IndexPath) -> [[String : Any]] {
       let questionPath = self.questionPath(for: indexPath)
       let type = self.type(for: questionPath)
-      if type != "text_field" {
+      if type != "text_field" && type != "dynamic_label_text_field" {
          return []
       }
       let question = self.question(for: questionPath)

--- a/SurveyNative/Classes/SurveyViewController.swift
+++ b/SurveyNative/Classes/SurveyViewController.swift
@@ -37,7 +37,11 @@ open class SurveyViewController: UIViewController {
    open func setCustomConditionDelegate(_ customConditionDelegate: CustomConditionDelegate) {
       surveyQuestions?.setCustomConditionDelegate(customConditionDelegate)
    }
-   
+
+   open func setValidationFailedDelegate(_ validationFailedDelegate: ValidationFailedDelegate) {
+      surveyQuestions?.validationFailedDelegate = validationFailedDelegate
+   }
+
    override open func viewDidLoad() {
       super.viewDidLoad()
       

--- a/SurveyNative/Classes/TableCellDataDelegate.swift
+++ b/SurveyNative/Classes/TableCellDataDelegate.swift
@@ -15,4 +15,5 @@ public protocol TableCellDataDelegate {
    func submitData()
    func updateActiveTextView(_ view: UIView)
    func validationFailed(message : String)
+   func answerForQuestion(id: String) -> Any
 }

--- a/SurveyNative/Classes/TableCellDataDelegate.swift
+++ b/SurveyNative/Classes/TableCellDataDelegate.swift
@@ -14,4 +14,5 @@ public protocol TableCellDataDelegate {
    func updateUI()
    func submitData()
    func updateActiveTextView(_ view: UIView)
+   func validationFailed(message : String)
 }

--- a/SurveyNative/Classes/TableViewCells/AddTextFieldTableViewCell.swift
+++ b/SurveyNative/Classes/TableViewCells/AddTextFieldTableViewCell.swift
@@ -45,7 +45,9 @@ class AddTextFieldTableViewCell: UITableViewCell, UITextFieldDelegate, TableView
    
    func cellDidActivate() {
       if extraTextFields.count > 0 {
-         extraTextFields[0].becomeFirstResponder()
+         if (extraTextFields[0].text == "") {
+            extraTextFields[0].becomeFirstResponder()
+         }
       }
    }
    
@@ -81,7 +83,9 @@ class AddTextFieldTableViewCell: UITableViewCell, UITextFieldDelegate, TableView
          dataDelegate?.updateUI()
       }
       if let nextField = nextTextField(sender) {
-         nextField.becomeFirstResponder()
+         if (nextField.text == "") {
+            nextField.becomeFirstResponder()
+         }
       }
    }
    

--- a/SurveyNative/Classes/TableViewCells/DynamicLabelTextFieldTableViewCell.swift
+++ b/SurveyNative/Classes/TableViewCells/DynamicLabelTextFieldTableViewCell.swift
@@ -29,6 +29,8 @@ class DynamicLabelTextFieldTableViewCell: UITableViewCell, UITextFieldDelegate, 
          }
       }
    }
+
+   var validations: [[String : Any]]?
    
    var labelOptions : [AnyHashable]?
    var optionsMetadata: [String : Any]?
@@ -153,7 +155,9 @@ class DynamicLabelTextFieldTableViewCell: UITableViewCell, UITextFieldDelegate, 
    }
    
    func textFieldDidEndEditing(_ textField: UITextField) {
-      sendUpdate()
+      if (validate().0) {
+         sendUpdate()
+      }
    }
    
    func sendUpdate() {
@@ -162,11 +166,19 @@ class DynamicLabelTextFieldTableViewCell: UITableViewCell, UITextFieldDelegate, 
    }
    
    @IBAction func tappedNextButton(_ sender: UIButton) {
+      let v = validate()
+      if (!v.0) {
+         self.dataDelegate?.validationFailed(message: v.1)
+         return
+      }
+
       sendUpdate()
    }
    
    @IBAction func actionTriggered(_ sender: UITextField) {
-      sendUpdate()
+      if (validate().0) {
+         sendUpdate()
+      }
    }
    
    func getData() -> [String : String] {
@@ -206,7 +218,56 @@ class DynamicLabelTextFieldTableViewCell: UITableViewCell, UITextFieldDelegate, 
          DynamicLabelTextFieldTableViewCell.metadataDefaults[self.metadataOptionsId()!] = self.metadataOptionsTypes()?[selectedIndex!]
       }
    }
-   
+
+   func textFieldWithLabel(label : String) -> UITextField? {
+      for (index, button) in self.buttons.enumerated() {
+         if button.title(for: UIControlState.normal) == label {
+            return self.textFields[index]
+         }
+      }
+      return nil
+   }
+
+   func validate() -> (Bool, String) {
+      if validations != nil {
+         for validation in self.validations! {
+            let textField : UITextField? = textFieldWithLabel(label: validation["for_label"] as! String)
+
+            if (textField != nil) {
+               if (!conditionMet(validation, answer: (textField?.text)!)) {
+                  let message : String = validation["on_fail_message"] as! String
+                  return (false, message)
+               }
+            }
+         }
+      }
+      return (true, "")
+   }
+
+   func conditionMet(_ condition : [String : Any], answer : String ) -> Bool {
+
+      let operationType : String = condition["operation"] as! String
+      var value : Any? = condition["value"]
+      let questionId : String? = condition["answer_to_question_id"] as! String?
+
+      if (questionId != nil) {
+         value = self.dataDelegate?.answerForQuestion(id : questionId!)
+      }
+
+      if (value == nil) {
+         Logger.log("Unable to check condition for unknown operation \"\(operationType)\" as value is nil, assuming false", level: .error)
+         return false
+      }
+
+      switch operationType {
+      case "greater than", "greater than or equal to", "less than", "less than or equal to":
+         return SurveyQuestions.numberComparison(answer: answer, value: value!, operation: operationType)
+      default:
+         Logger.log("Unable to check condition for unknown operation \"\(operationType)\", assuming false", level: .error)
+         return false
+      }
+   }
+
    @IBAction func labelTapped(_ sender: UIButton) {
       let alertController = UIAlertController(title: "Choose", message: nil, preferredStyle: .actionSheet)
       

--- a/SurveyNative/Classes/TableViewCells/DynamicLabelTextFieldTableViewCell.swift
+++ b/SurveyNative/Classes/TableViewCells/DynamicLabelTextFieldTableViewCell.swift
@@ -77,7 +77,9 @@ class DynamicLabelTextFieldTableViewCell: UITableViewCell, UITextFieldDelegate, 
    
    func cellDidActivate() {
       if textFields.count > 0 {
-         textFields[0].becomeFirstResponder()
+         if (textFields[0].text == "") {
+            textFields[0].becomeFirstResponder()
+         }
       }
    }
    

--- a/SurveyNative/Classes/TableViewCells/OtherOptionTableViewCell.swift
+++ b/SurveyNative/Classes/TableViewCells/OtherOptionTableViewCell.swift
@@ -120,7 +120,9 @@ class OtherOptionTableViewCell: UITableViewCell, UITextFieldDelegate, HasSelecti
       optionButton.isSelected = selected
       isSelectedOption = selected
       if selected {
-         textField?.becomeFirstResponder()
+         if (textField.text == "") {
+            textField?.becomeFirstResponder()
+         }
       } else {
          textField?.resignFirstResponder()
       }

--- a/SurveyNative/Classes/TableViewCells/OtherOptionTableViewCell.swift
+++ b/SurveyNative/Classes/TableViewCells/OtherOptionTableViewCell.swift
@@ -30,7 +30,9 @@ class OtherOptionTableViewCell: UITableViewCell, UITextFieldDelegate, HasSelecti
             return
          }
          if optionText != oldValue {
-            sendUpdate()
+            if (validate().0) {
+               sendUpdate()
+            }
          }
       }
    }
@@ -60,6 +62,8 @@ class OtherOptionTableViewCell: UITableViewCell, UITextFieldDelegate, HasSelecti
          updateButtonImages()
       }
    }
+
+   var validations: [[String : Any]]?
    
    override func awakeFromNib() {
       super.awakeFromNib()
@@ -96,6 +100,14 @@ class OtherOptionTableViewCell: UITableViewCell, UITextFieldDelegate, HasSelecti
    }
    
    @IBAction func tappedNextButton(_ sender: UIButton) {
+      if (textField != nil) {
+         let v = validate()
+         if (!v.0) {
+            self.dataDelegate?.validationFailed(message: v.1)
+            return
+         }
+      }
+
       self.optionText = textField?.text ?? ""
       textField?.resignFirstResponder()
    }
@@ -136,6 +148,44 @@ class OtherOptionTableViewCell: UITableViewCell, UITextFieldDelegate, HasSelecti
          nextButton?.isHidden = !shouldShowNextButton
       } else {
          nextButton?.isHidden = true
+      }
+   }
+
+   func validate() -> (Bool, String) {
+      if validations != nil {
+         for validation in self.validations! {
+            if (textField != nil) {
+               if (!conditionMet(validation, answer: (textField?.text)!)) {
+                  let message : String = validation["on_fail_message"] as! String
+                  return (false, message)
+               }
+            }
+         }
+      }
+      return (true, "")
+   }
+
+   func conditionMet(_ condition : [String : Any], answer : String ) -> Bool {
+
+      let operationType : String = condition["operation"] as! String
+      var value : Any? = condition["value"]
+      let questionId : String? = condition["answer_to_question_id"] as! String?
+
+      if (questionId != nil) {
+         value = self.dataDelegate?.answerForQuestion(id : questionId!)
+      }
+
+      if (value == nil) {
+         Logger.log("Unable to check condition for unknown operation \"\(operationType)\" as value is nil, assuming false", level: .error)
+         return false
+      }
+
+      switch operationType {
+      case "greater than", "greater than or equal to", "less than", "less than or equal to":
+         return SurveyQuestions.numberComparison(answer: answer, value: value!, operation: operationType)
+      default:
+         Logger.log("Unable to check condition for unknown operation \"\(operationType)\", assuming false", level: .error)
+         return false
       }
    }
 }

--- a/SurveyNative/Classes/TableViewCells/TextFieldTableViewCell.swift
+++ b/SurveyNative/Classes/TableViewCells/TextFieldTableViewCell.swift
@@ -115,11 +115,21 @@ class TextFieldTableViewCell: UITableViewCell, UITextFieldDelegate, TableViewCel
    func conditionMet(_ condition : [String : Any], answer : String ) -> Bool {
 
       let operationType : String = condition["operation"] as! String
-      let value : Any = condition["value"]!
+      var value : Any? = condition["value"]
+      let questionId : String? = condition["answer_to_question_id"] as! String?
+
+      if (questionId != nil) {
+         value = self.dataDelegate?.answerForQuestion(id : questionId!)
+      }
+
+      if (value == nil) {
+         Logger.log("Unable to check condition for unknown operation \"\(operationType)\" as value is nil, assuming false", level: .error)
+         return false
+      }
 
       switch operationType {
       case "greater than", "greater than or equal to", "less than", "less than or equal to":
-         return SurveyQuestions.numberComparison(answer: answer, value: value, operation: operationType)
+         return SurveyQuestions.numberComparison(answer: answer, value: value!, operation: operationType)
       default:
          Logger.log("Unable to check condition for unknown operation \"\(operationType)\", assuming false", level: .error)
          return false

--- a/SurveyNative/Classes/TableViewCells/TextFieldTableViewCell.swift
+++ b/SurveyNative/Classes/TableViewCells/TextFieldTableViewCell.swift
@@ -49,12 +49,16 @@ class TextFieldTableViewCell: UITableViewCell, UITextFieldDelegate, TableViewCel
    
    override func setSelected(_ selected: Bool, animated: Bool) {
       if selected {
-         textField?.becomeFirstResponder()
+         if (textField.text == "") {
+            textField?.becomeFirstResponder()
+         }
       }
    }
    
    func cellDidActivate() {
-      self.textField!.becomeFirstResponder()
+      if (self.textField.text == "") {
+         self.textField!.becomeFirstResponder()
+      }
    }
    
    func textFieldDidBeginEditing(_ textField: UITextField) {

--- a/SurveyNative/Classes/ValidationFailedDelegate.swift
+++ b/SurveyNative/Classes/ValidationFailedDelegate.swift
@@ -1,0 +1,13 @@
+//
+//  ValidationFailedDelegate.swift
+//  Pods
+//
+//  Created by Stuart Argue on 5/21/17.
+//
+//
+
+import Foundation
+
+public protocol ValidationFailedDelegate {
+   func validationFailed(message: String)
+}


### PR DESCRIPTION
Adding support for validation on single text field.

`validations` (_Array of Dictionaries_): Optional for `single_text_field` question_type. Check value meets the validations when `Next` tapped. If not `validationFailed(message: String)` is called on your `ValidationFailedDelegate`. Validations consist of an `operation`, `value` and `on_fail_message`. Supported operations:

    - `equals`
    - `not equals`
    - `greater than`
    - `greater than or equal to`
    - `less than`
    - `less than or equal to`