### PR TITLE
Compatibility fixes and optional URL

### DIFF
--- a/SurveyNative/Classes/DefaultTableCellDataDelegate.swift
+++ b/SurveyNative/Classes/DefaultTableCellDataDelegate.swift
@@ -45,8 +45,12 @@ open class DefaultTableCellDataDelegate : NSObject, TableCellDataDelegate {
    }
    
    open func submitData() {
+      guard let urlString = surveyQuestions.submitUrl() else {
+         self.submitCompletionHandler(nil, nil, nil)
+         return
+      }
+      let url = URL(string: urlString)
       let session = URLSession.shared
-      let url = URL(string: surveyQuestions.submitUrl())
       var request = URLRequest(url: url!)
       let jsonData = try? JSONSerialization.data(withJSONObject: surveyQuestions.submitJson())
       request.httpMethod = "POST"

--- a/SurveyNative/Classes/SurveyQuestions.swift
+++ b/SurveyNative/Classes/SurveyQuestions.swift
@@ -172,8 +172,8 @@ open class SurveyQuestions {
       return self.submitData["button_title"]!
    }
    
-   public func submitUrl() -> String {
-      return self.submitData["url"]!
+   public func submitUrl() -> String? {
+      return self.submitData["url"]
    }
    
    public func submitJson() -> [String : Any] {

--- a/SurveyNative/Classes/SurveyQuestions.swift
+++ b/SurveyNative/Classes/SurveyQuestions.swift
@@ -41,6 +41,10 @@ open class SurveyQuestions {
       return nil
    }
 
+   class open func load(_ json : Data, surveyTheme: SurveyTheme) -> SurveyQuestions? {
+      return SurveyQuestions.generateQuestions(withJsonData: json, surveyTheme: surveyTheme)
+   }
+
    class open func generateQuestions(withJsonData : Data, surveyTheme: SurveyTheme) -> SurveyQuestions? {
       var loadedQuestions : SurveyQuestions? = nil
       do {

--- a/SurveyNative/Classes/SurveyViewController.swift
+++ b/SurveyNative/Classes/SurveyViewController.swift
@@ -18,10 +18,14 @@ open class SurveyViewController: UIViewController {
    open var delegate : UITableViewDelegate?
    open var cellDataDelegate : TableCellDataDelegate?
    
-   open func surveyJsonFile() -> String {
-      preconditionFailure("This method must be overridden")
+   open func surveyJsonFile() -> String? {
+      return nil // must override this or surveyJson()
    }
    
+   open func surveyJson() -> Data? {
+      return nil // must override this or surveyJsonFile()
+   }
+    
    open func surveyTitle() -> String {
       preconditionFailure("This method must be overridden")
    }
@@ -45,8 +49,13 @@ open class SurveyViewController: UIViewController {
    override open func viewDidLoad() {
       super.viewDidLoad()
       
-      surveyQuestions = SurveyQuestions.load(surveyJsonFile(), surveyTheme: surveyTheme())
-      
+      if let jsonFile = surveyJsonFile() {
+         surveyQuestions = SurveyQuestions.load(jsonFile, surveyTheme: surveyTheme())
+      } else if let json = surveyJson() {
+          surveyQuestions = SurveyQuestions.load(json, surveyTheme: surveyTheme())
+      } else {
+          preconditionFailure("Must return non-nil from surveyJsonFile or surveyJsonURL")
+      }
       self.title = surveyTitle()
       
       self.navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: UIBarButtonItem.SystemItem.cancel, target: self, action: #selector(cancel));

--- a/SurveyNative/Classes/SurveyViewController.swift
+++ b/SurveyNative/Classes/SurveyViewController.swift
@@ -75,7 +75,7 @@ open class SurveyViewController: UIViewController {
       
       self.cellDataDelegate = DefaultTableCellDataDelegate(surveyQuestions!, tableView: tableView, submitCompletionHandler: { data, response, error -> Void in
           DispatchQueue.main.async {
-              self.dismiss(animated: true, completion: nil)
+             self.dismiss(animated: true, completion: nil)
           }
       })
       self.dataSource = SurveyDataSource(surveyQuestions!, surveyTheme: self.surveyTheme(), tableCellDataDelegate: cellDataDelegate!, presentationDelegate: self)

--- a/SurveyNative/Classes/SurveyViewController.swift
+++ b/SurveyNative/Classes/SurveyViewController.swift
@@ -30,6 +30,10 @@ open class SurveyViewController: UIViewController {
       preconditionFailure("This method must be overridden")
    }
    
+    open func previousAnswers() -> [String : Any]? {
+       return nil
+    }
+    
    open func surveyTheme() -> SurveyTheme {
       return DefaultSurveyTheme()
    }
@@ -57,6 +61,9 @@ open class SurveyViewController: UIViewController {
           preconditionFailure("Must return non-nil from surveyJsonFile or surveyJsonURL")
       }
       self.title = surveyTitle()
+      if let previousAnswers = previousAnswers() {
+         self.surveyQuestions!.answers = previousAnswers
+      }
       
       self.navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: UIBarButtonItem.SystemItem.cancel, target: self, action: #selector(cancel));
       

--- a/SurveyNative/Classes/SurveyViewController.swift
+++ b/SurveyNative/Classes/SurveyViewController.swift
@@ -58,7 +58,9 @@ open class SurveyViewController: UIViewController {
       tableView.addGestureRecognizer(tapRecognizer)
       
       self.cellDataDelegate = DefaultTableCellDataDelegate(surveyQuestions!, tableView: tableView, submitCompletionHandler: { data, response, error -> Void in
-         self.dismiss(animated: true, completion: nil)
+          DispatchQueue.main.async {
+              self.dismiss(animated: true, completion: nil)
+          }
       })
       self.dataSource = SurveyDataSource(surveyQuestions!, surveyTheme: self.surveyTheme(), tableCellDataDelegate: cellDataDelegate!, presentationDelegate: self)
       tableView.dataSource = dataSource

--- a/SurveyNative/Classes/TableViewCells/DynamicLabelTextFieldTableViewCell.swift
+++ b/SurveyNative/Classes/TableViewCells/DynamicLabelTextFieldTableViewCell.swift
@@ -248,7 +248,7 @@ class DynamicLabelTextFieldTableViewCell: UITableViewCell, UITextFieldDelegate, 
 
    @IBAction func labelTapped(_ sender: UIButton) {
       let alertController = UIAlertController(title: "Choose", message: nil, preferredStyle: .actionSheet)
-      
+      alertController.popoverPresentationController?.sourceView = self.contentView
       for option in labelOptions! {
          var title: String?
          if let stringOption = option as? String {


### PR DESCRIPTION
- Fix dismiss being called not on main thread
- Specify UIAlertController sourceView to fix crash on iOS 15/16. From memory I think this may be incompatible with an old iOS version.
- Make URL in survey question file optional, to skip upload. Useful when gathering the answer data through SurveyAnswerDelegate.